### PR TITLE
feat(#21): 입력 관련 컴포넌트 생성

### DIFF
--- a/src/components/input/InputLongText.tsx
+++ b/src/components/input/InputLongText.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import styled from 'styled-components';
 
 type setStateType = React.Dispatch<React.SetStateAction<any>>;

--- a/src/components/input/InputText.tsx
+++ b/src/components/input/InputText.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback } from 'react';
 import styled from 'styled-components';
 
 type setStateType = React.Dispatch<React.SetStateAction<any>>;


### PR DESCRIPTION





## InputText 컴포넌트 생성

문의하기 페이지 내에서 같은 형태의 입력 폼이 여러 개 있습니다.

그래서 컴포넌트화를 시켜서 재사용 할 수 있도록 했습니다.

추후에 등록을 위한 글쓰기를 할 때도 사용할 수 있을 것입니다.

```jsx
const InputText: React.FC<Props> = ({
  title,
  isEssential,
  placeholder,
  width,
  keyName,
  inputData,
  setInputData,
}) => {
  const handleChange = useCallback(
    (e: React.ChangeEvent<HTMLSelectElement>): void => {
      setInputData((prev: any) => ({ ...prev, [keyName]: e.target.value }));
    },
    [],
  );

  return (
    <Container>
      <TitleContainer>
        <Title>{title}</Title>
        {isEssential && <IconWrapper></IconWrapper>}
      </TitleContainer>
      <StyledInput
        type="text"
        value={inputData?.[keyName] || ''}
        width={width}
        placeholder={placeholder}
        onChange={handleChange}
      />
    </Container>
  );
};
```

Props로 전달받는 값은 다음과 같습니다.

Props 이름 | 역할
-- | --
title | 입력받는 데이터의 제목입니다. Ex) 기업 이름
isEssential | 필수 여부입니다.
placeholder | placeholder 입니다.
width | 너비입니다.
keyName | 해당 데이터가 저장될 key의 이름을 지정합니다.
inputData | 해당 데이터가 포함된 전체 데이터 state 입니다.
setInputData | inputData를 변경할 수 있는 setState 함수입니다.

---


## InputLongText 컴포넌트 생성

역시나 입력을 받기 위한 폼이지만, “내용”과 같은 긴 글이 입력될 때는 폼의 형태가 조금 다릅니다.

또한 “내용”의 경우엔 기입할 수 있는 Byte 수가 제한되기 때문에 이에 대해서도 다르게 적용해야 했습니다.

```jsx
const [dataByte, setDataByte] = useState<number>(0);

  const getByte = useCallback((str: string): number => {
    return str
      .split('')
      .map((s) => s.charCodeAt(0))
      .reduce((prev, c) => prev + (c === 10 ? 2 : c >> 7 ? 2 : 1), 0);
  }, []);

  const isFull = useCallback(() => (dataByte >= maxByte ? true : false), []);

  const handleChange = useCallback(
    (e: React.ChangeEvent<HTMLSelectElement>): void => {
      const {
        target: { value },
      } = e;
      const byteLength: number = getByte(value);

      if (byteLength > maxByte) return;
      setDataByte(byteLength);
      setInputData((prev: any) => ({ ...prev, [keyName]: value }));
    },
    [],
  );

  const handleKeyUp = useCallback(
    (e: React.KeyboardEvent<HTMLInputElement>) => {
      if (e?.key === 'Backspace' && isFull()) {
        const prevData = inputData?.[keyName];
        setInputData((prev: any) => ({
          ...prev,
          [keyName]: prevData?.slice(0, -1),
        }));
        setDataByte(getByte(inputData?.[keyName]));
      }
    },
    [],
  );
```

짧은 글 입력에 비해 사용되는 handler 함수가 많습니다.

먼저 Byte에 따라 입력을 제한해야 하기 때문에, getByte와 isFull이라는 함수를 만들었습니다.

isFull이 true를 반환하면 textarea는 readOnly 상태가 되어버립니다.

---

### 마주했던 문제

하지만 textarea를 readOnly 상태로 만들었을 때 문제가 발생합니다.

바이트가 가득차는 순간 textarea는 readOnly 상태가 되고, 그러면 지울 수 조차 없게 됩니다.

### 해결 방안

그래서 key 이벤트를 받아서 눌린 키가 백스페이스일 때만 글자를 하나 지울 수 있도록 했습니다.

이게 가장 까다로웠던 부분인 것 같습니다.

혹시 더 좋은 해결책이 있다면 제안해 주셔도 좋습니다.


이제 이 두 컴포넌트를 사용해서 문의하기 페이지를 만들 예정입니다.

---






















































































